### PR TITLE
Fix 404 issue when uri generated with jsessionid.

### DIFF
--- a/src/main/java/com/asual/lesscss/ResourceServlet.java
+++ b/src/main/java/com/asual/lesscss/ResourceServlet.java
@@ -161,7 +161,7 @@ public class ResourceServlet extends HttpServlet {
 	public void service(HttpServletRequest request, HttpServletResponse response) throws ServletException {
 		try {
 			ResourcePackage rp = ResourcePackage.fromString(request.getPathInfo());
-			String[] uri = (rp != null) ? rp.getResources() : new String[] {request.getRequestURI().replaceAll("/+", "/")};
+			String[] uri = (rp != null) ? rp.getResources() : new String[] {(request.getContextPath() + request.getServletPath() + (request.getServletPath() == null ? "" : request.getPathInfo()))}
 			String mimeType = getResourceMimeType(uri[0]);
 			long lastModified = 0;
 			byte[] content = new byte[0];


### PR DESCRIPTION
When cookies are disabled or, in my case, during first request <c:url> jstl tag generates uri like 
"/css/ipad.less;jsessionid=8F2DBDAD09DB189EAD4F531D3C555B4D"
This causes 404 response.
Concatenation of contextPath, servletPath and pathInfo instead of requestURI solves this issue and allows not to strip exceeded slashes.

Related discussion: https://issues.apache.org/bugzilla/show_bug.cgi?id=51833
