### PR TITLE
Only recompile LessResources when the file has been updated.

### DIFF
--- a/src/main/java/com/asual/lesscss/LessResource.java
+++ b/src/main/java/com/asual/lesscss/LessResource.java
@@ -85,9 +85,6 @@ public class LessResource extends StyleResource {
 			}
 
 			while (m.find()) {
-				logger.debug("Path: " + this.path);
-				logger.debug("OriginalUri: " + this.originalUri);
-				logger.debug("ImportResource URI: " + folder + m.group(1).replaceAll("\"|'", ""));
 				LessResource importedResource = new LessResource(
 						this.engine
 						, this.servletContext

--- a/src/main/java/com/asual/lesscss/LessResource.java
+++ b/src/main/java/com/asual/lesscss/LessResource.java
@@ -20,6 +20,8 @@ import org.apache.commons.logging.LogFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.servlet.ServletContext;
 
@@ -30,16 +32,18 @@ public class LessResource extends StyleResource {
 
 	private final Log logger = LogFactory.getLog(getClass());
 	private LessEngine engine;
+	private String originalUri;
 
 	public LessResource(LessEngine engine, ServletContext servletContext,
 			String uri, String charset, boolean cache, boolean compress)
 			throws ResourceNotFoundException {
 		super(servletContext, uri, charset, cache, compress);
+		this.originalUri = uri;
 		this.engine = engine;
 	}
 
 	public byte[] getContent() throws LessException, IOException {
-		if (content == null || !cache) {
+		if (content == null || (!cache && lastModified < getLastModified())) {
 			logger.debug("Not using cache.");
 			if (engine != null) {
 				logger.debug("LessEngine available, compiling.");
@@ -53,7 +57,7 @@ public class LessResource extends StyleResource {
 						(URL) resource, charset) : ResourceUtils.readTextFile(
 						(File) resource, charset);
 			}
-			lastModified = super.getLastModified();
+			lastModified = getLastModified();
 			if (compress) {
 				logger.debug("Compressing resource.");
 				compress();
@@ -63,6 +67,43 @@ public class LessResource extends StyleResource {
 					+ " and getLastModified: " + getLastModified());
 		}
 		return content;
+	}
+
+	public long getLastModified() throws IOException {
+		if (lastModified == null || !cache) {
+			lastModified = super.getLastModified();
+			String content = new String(
+				resource instanceof URL
+					? ResourceUtils.readTextUrl((URL) resource, charset)
+					: ResourceUtils.readTextFile((File) resource, charset)
+			);
+			Pattern p = Pattern.compile("@import\\s+(\"[^\"]*\"|'[^']*')");
+			Matcher m = p.matcher(content);
+			String folder = this.originalUri.substring(0, this.originalUri.lastIndexOf("/") + 1);
+			if(folder == null || folder == ""){
+				folder = this.originalUri.substring(0, this.originalUri.lastIndexOf("\\") + 1);
+			}
+
+			while (m.find()) {
+				logger.debug("Path: " + this.path);
+				logger.debug("OriginalUri: " + this.originalUri);
+				logger.debug("ImportResource URI: " + folder + m.group(1).replaceAll("\"|'", ""));
+				LessResource importedResource = new LessResource(
+						this.engine
+						, this.servletContext
+						, folder + m.group(1).replaceAll("\"|'", "")
+						, this.charset
+						, this.cache
+						, this.compress
+				);
+				long importedResourceLastModified = importedResource.getLastModified();
+				if (importedResourceLastModified > lastModified) {
+					lastModified = importedResourceLastModified;
+				}
+			}
+		}
+		logger.debug("getLastModified() in LessResource: " + lastModified);
+		return lastModified;
 	}
 
 }

--- a/src/test/resources/META-INF/css/import2.css
+++ b/src/test/resources/META-INF/css/import2.css
@@ -1,0 +1,5 @@
+@color: #F0F0F0;
+
+body {
+    color: @color;
+}

--- a/src/test/resources/META-INF/css/layer1/layer2/import.css
+++ b/src/test/resources/META-INF/css/layer1/layer2/import.css
@@ -1,0 +1,1 @@
+@import "../../import2.css";

--- a/src/test/resources/META-INF/css/test.css
+++ b/src/test/resources/META-INF/css/test.css
@@ -1,1 +1,1 @@
-@import "import.css";
+@import "layer1/layer2/import.css";


### PR DESCRIPTION
See my comments on issue https://github.com/asual/lesscss-servlet/issues/15.  This update restores the ability for LessResources to be cached until their LastModified (or the LastModified of any of their imports) changes.  This difference is only recognizable when the cache option is set to false.
